### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/IssueAssignment.yml
+++ b/.github/workflows/IssueAssignment.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
     auto-assign:
+        permissions:
+            contents: read
+            issues: write
         runs-on: ubuntu-latest
         steps:
             - name: 'Auto-assign issue'


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/spotify-save-new-music-friday/security/code-scanning/2](https://github.com/gioxx/spotify-save-new-music-friday/security/code-scanning/2)

In general, the fix is to explicitly define a `permissions` block that limits the `GITHUB_TOKEN` to the minimum scopes required by this workflow. This can be done at the workflow root (applies to all jobs) or per job. For this workflow, the action is triggered on `issues` events and assigns issues to a user, which only requires write access to issues; other scopes such as `contents` can remain read-only.

The best minimal change without altering behavior is to add a `permissions` block under the `auto-assign` job. That block should grant `issues: write` (so the action can modify issue assignees) and set `contents: read` as a safe default for repository contents. No other scopes are required. Concretely, in `.github/workflows/IssueAssignment.yml`, under `jobs: auto-assign:` and before `runs-on: ubuntu-latest`, add:

```yaml
        permissions:
            contents: read
            issues: write
```

This does not require any imports or additional definitions, just the YAML change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
