### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_backup_nmf.yml
+++ b/.github/workflows/test_backup_nmf.yml
@@ -1,5 +1,8 @@
 name: Backup New Music Friday TEST
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/gioxx/spotify-save-new-music-friday/security/code-scanning/1](https://github.com/gioxx/spotify-save-new-music-friday/security/code-scanning/1)

In general, to fix this issue you should explicitly declare a `permissions:` block in the workflow (either at the root so it applies to all jobs, or per job) and set the minimal needed permissions. Since this workflow only needs to read repository contents (for checkout) and does not currently push changes or interact with other GitHub resources, `contents: read` is sufficient.

The best fix here is to add a root-level `permissions` section just under the `name:` (and before `on:`) in `.github/workflows/test_backup_nmf.yml`:

- Add:
  ```yaml
  permissions:
    contents: read
  ```
  at the top level of the workflow file.
- Do not alter any steps or environment variables, and do not re-enable the commented-out commit/push steps.
- No extra imports or external libraries are required, as this is purely a YAML workflow configuration change.

Concretely:
- In `.github/workflows/test_backup_nmf.yml`, between line 1 (`name: Backup New Music Friday TEST`) and line 3 (`on:`), insert the `permissions:` block. This will apply to the entire workflow and limit `GITHUB_TOKEN` to read-only access to repository contents.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
